### PR TITLE
Rtt calculation. Closes #73

### DIFF
--- a/worker/include/RTC/RtpSender.hpp
+++ b/worker/include/RTC/RtpSender.hpp
@@ -8,6 +8,7 @@
 #include "RTC/RtpPacket.hpp"
 #include "RTC/RtpDataCounter.hpp"
 #include "RTC/RTCP/Sdes.hpp"
+#include "RTC/RTCP/ReceiverReport.hpp"
 #include "RTC/RTCP/FeedbackRtpNack.hpp"
 #include "RTC/RTCP/CompoundPacket.hpp"
 #include "Channel/Request.hpp"
@@ -61,6 +62,7 @@ namespace RTC
 		void SendRtpPacket(RTC::RtpPacket* packet);
 		void GetRtcp(RTC::RTCP::CompoundPacket *packet, uint64_t now);
 		void ReceiveNack(RTC::RTCP::FeedbackRtpNackPacket* nackPacket);
+		void ReceiveRtcpReceiverReport(RTC::RTCP::ReceiverReport* report);
 		uint32_t GetTransmissionRate(uint64_t now);
 
 	private:

--- a/worker/include/RTC/RtpStreamSend.hpp
+++ b/worker/include/RTC/RtpStreamSend.hpp
@@ -3,6 +3,7 @@
 
 #include "RTC/RtpStream.hpp"
 #include "RTC/RTCP/SenderReport.hpp"
+#include "RTC/RTCP/ReceiverReport.hpp"
 #include <vector>
 #include <list>
 
@@ -30,8 +31,10 @@ namespace RTC
 
 		virtual Json::Value toJson() const override;
 		bool ReceivePacket(RTC::RtpPacket* packet) override;
+		void ReceiveRtcpReceiverReport(RTC::RTCP::ReceiverReport* report);
 		void RequestRtpRetransmission(uint16_t seq, uint16_t bitmask, std::vector<RTC::RtpPacket*>& container);
 		RTC::RTCP::SenderReport* GetRtcpSenderReport(uint64_t now);
+		uint32_t GetRtt() const;
 
 	private:
 		void ClearBuffer();
@@ -50,7 +53,14 @@ namespace RTC
 		size_t receivedBytes = 0; // Bytes received.
 		uint64_t lastPacketTimeMs = 0; // Time (MS) when the last packet was received.
 		uint32_t lastPacketRtpTimestamp = 0; // RTP Timestamp of the last packet.
+		uint32_t rtt; // Round trip time.
 	};
+
+	inline
+	uint32_t RtpStreamSend::GetRtt() const
+	{
+		return this->rtt;
+	}
 }
 
 #endif

--- a/worker/src/RTC/Room.cpp
+++ b/worker/src/RTC/Room.cpp
@@ -624,8 +624,7 @@ namespace RTC
 
 		MS_ASSERT(this->mapRtpSenderRtpReceiver.find(rtpSender) != this->mapRtpSenderRtpReceiver.end(), "RtpSender not present in the map");
 
-		// TODO: Calculate real downstream stats for the given RtpSender,
-		// considering the ReceiverReport generated locally and this one.
+		rtpSender->ReceiveRtcpReceiverReport(report);
 	}
 
 	void Room::onPeerRtcpFeedback(RTC::Peer* peer, RTC::RtpSender* rtpSender, RTC::RTCP::FeedbackPsPacket* packet)

--- a/worker/src/RTC/RtpSender.cpp
+++ b/worker/src/RTC/RtpSender.cpp
@@ -385,6 +385,20 @@ namespace RTC
 		}
 	}
 
+	void RtpSender::ReceiveRtcpReceiverReport(RTC::RTCP::ReceiverReport* report)
+	{
+		MS_TRACE();
+
+		if (!this->rtpStream)
+		{
+			MS_WARN_TAG(rtp, "no RtpStreamSend");
+
+			return;
+		}
+
+		this->rtpStream->ReceiveRtcpReceiverReport(report);
+	}
+
 	void RtpSender::CreateRtpStream(RTC::RtpEncodingParameters& encoding)
 	{
 		MS_TRACE();


### PR DESCRIPTION
RTT calculation.

While testing I've realised that Chrome is not setting the LSR and DLSR values on Receiver Reports (always come with a value of zero).

Firefox generates the Receiver Reports properly.

I need to check a bit more on Chrome side. 

Chrome: Version 59.0.3047.0 (Official Build) dev (64-bit)